### PR TITLE
7zip directory fix

### DIFF
--- a/create cbz from folders.bat
+++ b/create cbz from folders.bat
@@ -1,3 +1,3 @@
 @Echo Off 
-FOR /D /r %%G in (*) DO 7za.exe a -tzip "%%~nxG.cbz" "%%~nxG\*.*"
+FOR /D /r %%G in (*) DO "C:\Program Files\7-Zip\7z.exe" a -tzip "%%~nxG.cbz" "%%~nxG\*.*"  & :: Don't forget to change your drive name if 7zip is not stored at "C:\"
 ::FOR /D /r %%G in (*) DO RMDIR /S /Q "%%~nxG"


### PR DESCRIPTION
Specified 7zip install directory, otherwise it can't find it and doesn't work, also updated "7za.exe" to "7z.exe"

(Tested by converting over 100 folders to .cbz, works perfectly)